### PR TITLE
Add support for command bus like syntax, Drop PHP 8.1

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -21,7 +21,6 @@ jobs:
                     - "lowest"
                     - "highest"
                 php-version:
-                    - "8.1"
                     - "8.2"
                     - "8.3"
                 operating-system:

--- a/README.md
+++ b/README.md
@@ -121,6 +121,48 @@ final class ProfileTest extends AggregateRootTestCase
 }
 ```
 
+### Using Commandbus like syntax
+
+When using the command bus and the `#[Handle]` attributes in your aggregate you can also provide the command directly
+for the `when` method.
+
+```php
+final class ProfileTest extends AggregateRootTestCase
+{ 
+    // protected function aggregateClass(): string;
+    
+    public function testBehaviour(): void
+    {
+        $this
+            ->when(new CreateProfile(ProfileId::fromString('1'), Email::fromString('hq@patchlevel.de')))
+            ->then(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('hq@patchlevel.de')));
+    }
+}
+```
+
+If more parameters than the command is needed, these can also be provided as additional parameters for `when`. In this
+example the we need a string which will be directly passed to the event.
+
+```php
+final class ProfileTest extends AggregateRootTestCase
+{ 
+    // protected function aggregateClass(): string;
+    
+    public function testBehaviour(): void
+    {
+        $this
+            ->given(
+                new ProfileCreated(
+                    ProfileId::fromString('1'),
+                    Email::fromString('hq@patchlevel.de'),
+                ),
+            )
+            ->when(new VisitProfile(ProfileId::fromString('2')), 'Extra Parameter / Dependency')
+            ->then(new ProfileVisited(ProfileId::fromString('2'), 'Extra Parameter / Dependency'));
+    }
+}
+```
+
 ## Testing Subscriber
 
 For testing a subscriber there is a utility class which you can use. Using `SubscriberUtilities` will provide you a

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     }
   ],
   "require": {
-    "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-    "patchlevel/event-sourcing": "^3.0.0",
+    "php": "~8.2.0 || ~8.3.0",
+    "patchlevel/event-sourcing": "^3.8.0",
     "phpunit/phpunit": "^10.1.0||^11.0.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c33a570d9d250be69b61dd5ddbaa1a1",
+    "content-hash": "19fa444d48ecdc34f63e00aa845d96d6",
     "packages": [
         {
             "name": "brick/math",
@@ -413,16 +413,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.1",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
+                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
+                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
                 "shasum": ""
             },
             "require": {
@@ -461,7 +461,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
             },
             "funding": [
                 {
@@ -469,7 +469,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T17:47:46+00:00"
+            "time": "2025-02-12T12:17:51+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -4427,16 +4427,16 @@
         },
         {
             "name": "infection/infection",
-            "version": "0.29.10",
+            "version": "0.29.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/infection/infection.git",
-                "reference": "cac7d20e5d286a37488527e477f5a695a9d7a44c"
+                "reference": "e241c8f58cf4121818c5a20a74ebb321dd94bb25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infection/infection/zipball/cac7d20e5d286a37488527e477f5a695a9d7a44c",
-                "reference": "cac7d20e5d286a37488527e477f5a695a9d7a44c",
+                "url": "https://api.github.com/repos/infection/infection/zipball/e241c8f58cf4121818c5a20a74ebb321dd94bb25",
+                "reference": "e241c8f58cf4121818c5a20a74ebb321dd94bb25",
                 "shasum": ""
             },
             "require": {
@@ -4458,7 +4458,7 @@
                 "php": "^8.2",
                 "sanmai/later": "^0.1.1",
                 "sanmai/pipeline": "^5.1 || ^6",
-                "sebastian/diff": "^3.0.2 || ^4.0 || ^5.0 || ^6.0",
+                "sebastian/diff": "^3.0.2 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
                 "shish/safe": "^2.6",
                 "symfony/console": "^5.4 || ^6.0 || ^7.0",
                 "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
@@ -4539,7 +4539,7 @@
             ],
             "support": {
                 "issues": "https://github.com/infection/infection/issues",
-                "source": "https://github.com/infection/infection/tree/0.29.10"
+                "source": "https://github.com/infection/infection/tree/0.29.11"
             },
             "funding": [
                 {
@@ -4551,7 +4551,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-12-17T19:11:10+00:00"
+            "time": "2025-02-11T10:05:15+00:00"
         },
         {
             "name": "infection/mutator",
@@ -4853,16 +4853,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.3",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "64ae44e48214f3deebdaeebf2694297a10a2bea9"
+                "reference": "8f99e18eb775dbaf6460c95fa0b65312da9c746a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/64ae44e48214f3deebdaeebf2694297a10a2bea9",
-                "reference": "64ae44e48214f3deebdaeebf2694297a10a2bea9",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8f99e18eb775dbaf6460c95fa0b65312da9c746a",
+                "reference": "8f99e18eb775dbaf6460c95fa0b65312da9c746a",
                 "shasum": ""
             },
             "require": {
@@ -4907,7 +4907,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-07T15:05:24+00:00"
+            "time": "2025-02-10T08:25:21+00:00"
         },
         {
             "name": "sanmai/later",
@@ -5530,7 +5530,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/tests/Unit/Fixture/CreateProfile.php
+++ b/tests/Unit/Fixture/CreateProfile.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture;
+
+final readonly class CreateProfile
+{
+    public function __construct(
+        public ProfileId $id,
+        public Email $email,
+    ) {
+    }
+}

--- a/tests/Unit/Fixture/Profile.php
+++ b/tests/Unit/Fixture/Profile.php
@@ -7,6 +7,7 @@ namespace Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture;
 use Patchlevel\EventSourcing\Aggregate\BasicAggregateRoot;
 use Patchlevel\EventSourcing\Attribute\Aggregate;
 use Patchlevel\EventSourcing\Attribute\Apply;
+use Patchlevel\EventSourcing\Attribute\Handle;
 use Patchlevel\EventSourcing\Attribute\Id;
 
 #[Aggregate('profile')]
@@ -27,17 +28,19 @@ final class Profile extends BasicAggregateRoot
         return $this->email;
     }
 
-    public static function createProfile(ProfileId $id, Email $email): self
+    #[Handle]
+    public static function createProfile(CreateProfile $createProfile): self
     {
         $self = new self();
-        $self->recordThat(new ProfileCreated($id, $email));
+        $self->recordThat(new ProfileCreated($createProfile->id, $createProfile->email));
 
         return $self;
     }
 
-    public function visitProfile(ProfileId $profileId): void
+    #[Handle]
+    public function visitProfile(VisitProfile $visitProfile, string|null $token = null): void
     {
-        $this->recordThat(new ProfileVisited($profileId));
+        $this->recordThat(new ProfileVisited($visitProfile->id, $token));
     }
 
     public function throwException(): void

--- a/tests/Unit/Fixture/ProfileVisited.php
+++ b/tests/Unit/Fixture/ProfileVisited.php
@@ -14,6 +14,7 @@ final class ProfileVisited implements Stringable
     public function __construct(
         #[IdNormalizer]
         public ProfileId $visitorId,
+        public string|null $token = null,
     ) {
     }
 

--- a/tests/Unit/Fixture/VisitProfile.php
+++ b/tests/Unit/Fixture/VisitProfile.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture;
+
+final readonly class VisitProfile
+{
+    public function __construct(
+        public ProfileId $id,
+    ) {
+    }
+}


### PR DESCRIPTION
Add Commandbus like syntax to ease the testing even more. Bump therefore the requirement of event-sourcing to 3.8.0 as there the commandbus feature released.