### PR TITLE
Handle throwing exceptions when creating the aggregate better.

### DIFF
--- a/src/Test/AggregateRootTestCase.php
+++ b/src/Test/AggregateRootTestCase.php
@@ -118,6 +118,8 @@ abstract class AggregateRootTestCase extends TestCase
             }
         } catch (Throwable $throwable) {
             $this->handleException($throwable);
+
+            return $this;
         }
 
         if (!$aggregate instanceof AggregateRoot) {

--- a/tests/Unit/Fixture/CreateProfileException.php
+++ b/tests/Unit/Fixture/CreateProfileException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture;
+
+final readonly class CreateProfileException
+{
+    public function __construct(
+        public ProfileId $id,
+        public Email $email,
+    ) {
+    }
+}

--- a/tests/Unit/Fixture/CreateProfileWithFailure.php
+++ b/tests/Unit/Fixture/CreateProfileWithFailure.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture;
 
-final readonly class CreateProfileException
+final readonly class CreateProfileWithFailure
 {
     public function __construct(
         public ProfileId $id,

--- a/tests/Unit/Fixture/Profile.php
+++ b/tests/Unit/Fixture/Profile.php
@@ -38,6 +38,13 @@ final class Profile extends BasicAggregateRoot
     }
 
     #[Handle]
+    public static function createProfileException(CreateProfileException $createProfile): void
+    {
+        $self = new self();
+        $self->throwException();
+    }
+
+    #[Handle]
     public function visitProfile(VisitProfile $visitProfile, string|null $token = null): void
     {
         $this->recordThat(new ProfileVisited($visitProfile->id, $token));

--- a/tests/Unit/Fixture/Profile.php
+++ b/tests/Unit/Fixture/Profile.php
@@ -38,7 +38,7 @@ final class Profile extends BasicAggregateRoot
     }
 
     #[Handle]
-    public static function createProfileException(CreateProfileException $createProfile): void
+    public static function createProfileException(CreateProfileWithFailure $createProfile): void
     {
         $self = new self();
         $self->throwException();

--- a/tests/Unit/Test/AggregateRootTestCaseTest.php
+++ b/tests/Unit/Test/AggregateRootTestCaseTest.php
@@ -11,6 +11,7 @@ use Patchlevel\EventSourcing\PhpUnit\Test\AggregateRootTestCase;
 use Patchlevel\EventSourcing\PhpUnit\Test\NoAggregateCreated;
 use Patchlevel\EventSourcing\PhpUnit\Test\NoWhenProvided;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\CreateProfile;
+use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\CreateProfileException;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\Email;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\ProfileCreated;
@@ -40,7 +41,7 @@ final class AggregateRootTestCaseTest extends TestCase
             ->expectsException(ProfileError::class);
 
         $test->assert();
-        self::assertSame(2, $test::getCount());
+        self::assertSame(1, $test::getCount());
     }
 
     public function testExceptionMessage(): void
@@ -60,7 +61,7 @@ final class AggregateRootTestCaseTest extends TestCase
             ->expectsExceptionMessage('throwing so that you can catch it!');
 
         $test->assert();
-        self::assertSame(2, $test::getCount());
+        self::assertSame(1, $test::getCount());
     }
 
     public function testExceptionAndMessage(): void
@@ -81,7 +82,7 @@ final class AggregateRootTestCaseTest extends TestCase
             ->expectsExceptionMessage('throwing so that you can catch it!');
 
         $test->assert();
-        self::assertSame(3, $test::getCount());
+        self::assertSame(2, $test::getCount());
     }
 
     public function testExceptionUncatched(): void
@@ -100,6 +101,24 @@ final class AggregateRootTestCaseTest extends TestCase
             );
 
         $this->expectException(ProfileError::class);
+        $test->assert();
+        self::assertSame(1, $test::getCount());
+    }
+
+    public function testExceptionWhenCreating(): void
+    {
+        $test = $this->getTester();
+
+        $test
+            ->when(
+                new CreateProfileException(
+                    ProfileId::fromString('1'),
+                    Email::fromString('hq@patchlevel.de'),
+                ),
+            )
+            ->expectsException(ProfileError::class)
+            ->expectsExceptionMessage('throwing so that you can catch it!');
+
         $test->assert();
         self::assertSame(2, $test::getCount());
     }

--- a/tests/Unit/Test/AggregateRootTestCaseTest.php
+++ b/tests/Unit/Test/AggregateRootTestCaseTest.php
@@ -11,7 +11,7 @@ use Patchlevel\EventSourcing\PhpUnit\Test\AggregateRootTestCase;
 use Patchlevel\EventSourcing\PhpUnit\Test\NoAggregateCreated;
 use Patchlevel\EventSourcing\PhpUnit\Test\NoWhenProvided;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\CreateProfile;
-use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\CreateProfileException;
+use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\CreateProfileWithFailure;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\Email;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\ProfileCreated;
@@ -111,7 +111,7 @@ final class AggregateRootTestCaseTest extends TestCase
 
         $test
             ->when(
-                new CreateProfileException(
+                new CreateProfileWithFailure(
                     ProfileId::fromString('1'),
                     Email::fromString('hq@patchlevel.de'),
                 ),


### PR DESCRIPTION
 Now, it won't assert the events anymore if an exception is thrown.