### PR TITLE
Allow Closures in `then()` for assertions on resulting aggregate state

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ When this is done, you already can start testing your behaviour. For example tes
 
 ```php
 final class ProfileTest extends AggregateRootTestCase
-{ 
+{
     // protected function aggregateClass(): string;
-    
+
     public function testBehaviour(): void
     {
         $this
@@ -55,9 +55,9 @@ You can also provide multiple given events and expect multiple events:
 
 ```php
 final class ProfileTest extends AggregateRootTestCase
-{ 
+{
     // protected function aggregateClass(): string;
-    
+
     public function testBehaviour(): void
     {
         $this
@@ -86,9 +86,9 @@ You can also test the creation of the aggregate:
 
 ```php
 final class ProfileTest extends AggregateRootTestCase
-{ 
+{
     // protected function aggregateClass(): string;
-    
+
     public function testBehaviour(): void
     {
         $this
@@ -102,9 +102,9 @@ And expect an exception and the message of it:
 
 ```php
 final class ProfileTest extends AggregateRootTestCase
-{ 
+{
     // protected function aggregateClass(): string;
-    
+
     public function testBehaviour(): void
     {
         $this
@@ -121,6 +121,39 @@ final class ProfileTest extends AggregateRootTestCase
 }
 ```
 
+### Asserting aggregate state
+
+You can pass closures to `then()` to assert on the aggregate's state after the events have been applied. This is useful
+when your aggregate exposes state via public properties or getters that are set in `apply` methods. Closures receive the
+aggregate instance and are executed after the event assertion. You can mix closures and expected events freely — event
+order is preserved regardless of callback placement.
+
+```php
+final class ProfileTest extends AggregateRootTestCase
+{
+    // protected function aggregateClass(): string;
+
+    public function testBehaviour(): void
+    {
+        $this
+            ->given(
+                new ProfileCreated(
+                    ProfileId::fromString('1'),
+                    Email::fromString('hq@patchlevel.de'),
+                ),
+            )
+            ->when(static fn (Profile $profile) => $profile->visitProfile(ProfileId::fromString('2')))
+            ->then(
+                new ProfileVisited(ProfileId::fromString('2')),
+                static fn (Profile $profile) => self::assertSame('1', $profile->id()->toString()),
+            );
+    }
+}
+```
+
+> [!NOTE]
+> When `then()` receives only closures and no event objects, it strictly asserts that zero events were emitted.
+
 ### Using Commandbus like syntax
 
 When using the command bus and the `#[Handle]` attributes in your aggregate you can also provide the command directly
@@ -128,9 +161,9 @@ for the `when` method.
 
 ```php
 final class ProfileTest extends AggregateRootTestCase
-{ 
+{
     // protected function aggregateClass(): string;
-    
+
     public function testBehaviour(): void
     {
         $this
@@ -145,9 +178,9 @@ example the we need a string which will be directly passed to the event.
 
 ```php
 final class ProfileTest extends AggregateRootTestCase
-{ 
+{
     // protected function aggregateClass(): string;
-    
+
     public function testBehaviour(): void
     {
         $this
@@ -213,10 +246,10 @@ final class ProfileSubscriberTest extends TestCase
 {
     use SubscriberUtilities;
 
-    public function testProfileCreated(): void 
+    public function testProfileCreated(): void
     {
         $subscriber = new ProfileSubscriber(/* inject deps, if needed */);
-        
+
         $util = new SubscriberUtilities($subscriber);
         $util->executeSetup();
         $util->executeRun(
@@ -226,15 +259,15 @@ final class ProfileSubscriberTest extends TestCase
             )
         );
        $util->executeTeardown();
-     
+
         self::assertSame(3, $subscriber->count);
     }
 }
 ```
 
-This Util class can be used for integration or unit tests. 
+This Util class can be used for integration or unit tests.
 
-You can also pass `Message` instances with additional headers to the `executeRun` method. This allows testing 
+You can also pass `Message` instances with additional headers to the `executeRun` method. This allows testing
 subscribers that rely on additional parameters like header information:
 
 
@@ -267,10 +300,10 @@ final class ProfileSubscriberTest extends TestCase
 {
     use SubscriberUtilities;
 
-    public function testProfileCreated(): void 
+    public function testProfileCreated(): void
     {
         /* Setup and Teardown as before */
-        
+
         $util->executeRun(
             Message::createWithHeaders(
                 new ProfileCreated(
@@ -280,7 +313,7 @@ final class ProfileSubscriberTest extends TestCase
                 [new RecordedOnHeader(new DateTimeImmutable('now'))],
             )
         );
-       
+
        /* Your assertions */
     }
 }

--- a/src/Test/AggregateRootTestCase.php
+++ b/src/Test/AggregateRootTestCase.php
@@ -7,7 +7,6 @@ namespace Patchlevel\EventSourcing\PhpUnit\Test;
 use Closure;
 use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
 use Patchlevel\EventSourcing\CommandBus\HandlerFinder;
-use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Constraint\Exception as ExceptionConstraint;
@@ -111,7 +110,7 @@ abstract class AggregateRootTestCase extends TestCase
                     $reflection = new ReflectionClass($this->aggregateClass());
                     $reflectionMethod = $reflection->getMethod($handler->method);
 
-                    $return = $reflectionMethod->invokeArgs($handler->static ? null : $aggregate, [$callableOrCommand, ...$this->parameters,]);
+                    $return = $reflectionMethod->invokeArgs($handler->static ? null : $aggregate, [$callableOrCommand, ...$this->parameters]);
                 }
             }
 
@@ -132,8 +131,8 @@ abstract class AggregateRootTestCase extends TestCase
             throw new NoAggregateCreated();
         }
 
-        $expectedEvents = array_values(array_filter($this->thenExpectations, static fn(object $item) => !$item instanceof Closure));
-        $expectationCallbacks = array_filter($this->thenExpectations, static fn(object $item) => $item instanceof Closure);
+        $expectedEvents = array_values(array_filter($this->thenExpectations, static fn (object $item) => !$item instanceof Closure));
+        $expectationCallbacks = array_filter($this->thenExpectations, static fn (object $item) => $item instanceof Closure);
 
         $events = $aggregate->releaseEvents();
 
@@ -142,8 +141,6 @@ abstract class AggregateRootTestCase extends TestCase
         foreach ($expectationCallbacks as $callback) {
             try {
                 $callback($aggregate);
-            } catch (AssertionFailedError $e) {
-                throw $e;
             } catch (Throwable $t) {
                 $reflection = new ReflectionFunction($callback);
 
@@ -177,12 +174,12 @@ abstract class AggregateRootTestCase extends TestCase
         $checked = false;
 
         if ($this->expectedException) {
-            self::assertThat($throwable, new ExceptionConstraint($this->expectedException,));
+            self::assertThat($throwable, new ExceptionConstraint($this->expectedException));
             $checked = true;
         }
 
         if ($this->expectedExceptionMessage) {
-            self::assertThat($throwable->getMessage(), new ExceptionMessageIsOrContains($this->expectedExceptionMessage,));
+            self::assertThat($throwable->getMessage(), new ExceptionMessageIsOrContains($this->expectedExceptionMessage));
             $checked = true;
         }
 

--- a/src/Test/AggregateRootTestCase.php
+++ b/src/Test/AggregateRootTestCase.php
@@ -13,10 +13,13 @@ use PHPUnit\Framework\Constraint\Exception as ExceptionConstraint;
 use PHPUnit\Framework\Constraint\ExceptionMessageIsOrContains;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use ReflectionFunction;
 use Throwable;
+use TypeError;
 
 use function array_filter;
 use function array_values;
+use function sprintf;
 
 abstract class AggregateRootTestCase extends TestCase
 {
@@ -143,7 +146,21 @@ abstract class AggregateRootTestCase extends TestCase
         self::assertEquals($expectedEvents, $events, 'The events doesn\'t match the expected events.');
 
         foreach ($expectationCallbacks as $callback) {
-            $callback($aggregate);
+            try {
+                $callback($aggregate);
+            } catch (TypeError $e) {
+                $reflection = new ReflectionFunction($callback);
+
+                throw new TypeError(
+                    sprintf(
+                        'Invalid then() callback defined in %s on line %d: %s',
+                        $reflection->getFileName(),
+                        $reflection->getStartLine(),
+                        $e->getMessage(),
+                    ),
+                    previous: $e,
+                );
+            }
         }
 
         return $this;

--- a/src/Test/AggregateRootTestCase.php
+++ b/src/Test/AggregateRootTestCase.php
@@ -7,6 +7,7 @@ namespace Patchlevel\EventSourcing\PhpUnit\Test;
 use Closure;
 use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
 use Patchlevel\EventSourcing\CommandBus\HandlerFinder;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Constraint\Exception as ExceptionConstraint;
@@ -15,7 +16,6 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionFunction;
 use Throwable;
-use TypeError;
 
 use function array_filter;
 use function array_values;
@@ -33,7 +33,7 @@ abstract class AggregateRootTestCase extends TestCase
     /** @var array<object|Closure> */
     private array $thenExpectations = [];
 
-    /** @var class-string<Throwable>|null  */
+    /** @var class-string<Throwable>|null */
     private string|null $expectedException = null;
     private string|null $expectedExceptionMessage = null;
 
@@ -111,13 +111,7 @@ abstract class AggregateRootTestCase extends TestCase
                     $reflection = new ReflectionClass($this->aggregateClass());
                     $reflectionMethod = $reflection->getMethod($handler->method);
 
-                    $return = $reflectionMethod->invokeArgs(
-                        $handler->static ? null : $aggregate,
-                        [
-                            $callableOrCommand,
-                            ...$this->parameters,
-                        ],
-                    );
+                    $return = $reflectionMethod->invokeArgs($handler->static ? null : $aggregate, [$callableOrCommand, ...$this->parameters,]);
                 }
             }
 
@@ -138,8 +132,8 @@ abstract class AggregateRootTestCase extends TestCase
             throw new NoAggregateCreated();
         }
 
-        $expectedEvents = array_values(array_filter($this->thenExpectations, static fn (object $item) => !$item instanceof Closure));
-        $expectationCallbacks = array_filter($this->thenExpectations, static fn (object $item) => $item instanceof Closure);
+        $expectedEvents = array_values(array_filter($this->thenExpectations, static fn(object $item) => !$item instanceof Closure));
+        $expectationCallbacks = array_filter($this->thenExpectations, static fn(object $item) => $item instanceof Closure);
 
         $events = $aggregate->releaseEvents();
 
@@ -148,17 +142,18 @@ abstract class AggregateRootTestCase extends TestCase
         foreach ($expectationCallbacks as $callback) {
             try {
                 $callback($aggregate);
-            } catch (TypeError $e) {
+            } catch (AssertionFailedError $e) {
+                throw $e;
+            } catch (Throwable $t) {
                 $reflection = new ReflectionFunction($callback);
 
-                throw new TypeError(
+                self::fail(
                     sprintf(
-                        'Invalid then() callback defined in %s on line %d: %s',
+                        'then() callback defined in %s on line %d failed: %s',
                         $reflection->getFileName(),
                         $reflection->getStartLine(),
-                        $e->getMessage(),
+                        $t->getMessage(),
                     ),
-                    previous: $e,
                 );
             }
         }
@@ -182,22 +177,12 @@ abstract class AggregateRootTestCase extends TestCase
         $checked = false;
 
         if ($this->expectedException) {
-            self::assertThat(
-                $throwable,
-                new ExceptionConstraint(
-                    $this->expectedException,
-                ),
-            );
+            self::assertThat($throwable, new ExceptionConstraint($this->expectedException,));
             $checked = true;
         }
 
         if ($this->expectedExceptionMessage) {
-            self::assertThat(
-                $throwable->getMessage(),
-                new ExceptionMessageIsOrContains(
-                    $this->expectedExceptionMessage,
-                ),
-            );
+            self::assertThat($throwable->getMessage(), new ExceptionMessageIsOrContains($this->expectedExceptionMessage,));
             $checked = true;
         }
 

--- a/src/Test/AggregateRootTestCase.php
+++ b/src/Test/AggregateRootTestCase.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Throwable;
 
+use function array_filter;
+use function array_values;
+
 abstract class AggregateRootTestCase extends TestCase
 {
     /** @var array<object> */
@@ -24,8 +27,9 @@ abstract class AggregateRootTestCase extends TestCase
     /** @var array<mixed> */
     private array $parameters = [];
 
-    /** @var array<object> */
-    private array $expectedEvents = [];
+    /** @var array<object|Closure> */
+    private array $thenExpectations = [];
+
     /** @var class-string<Throwable>|null  */
     private string|null $expectedException = null;
     private string|null $expectedExceptionMessage = null;
@@ -49,9 +53,14 @@ abstract class AggregateRootTestCase extends TestCase
         return $this;
     }
 
+    /**
+     * @param object|Closure(object): void ...$events Expected events and/or callbacks for aggregate state assertions.
+     *                                                Closures receive the aggregate instance and are executed after event assertions.
+     *                                                Event order is preserved regardless of callback placement.
+     */
     final public function then(object ...$events): self
     {
-        $this->expectedEvents = $events;
+        $this->thenExpectations = $events;
 
         return $this;
     }
@@ -126,9 +135,16 @@ abstract class AggregateRootTestCase extends TestCase
             throw new NoAggregateCreated();
         }
 
+        $expectedEvents = array_values(array_filter($this->thenExpectations, static fn (object $item) => !$item instanceof Closure));
+        $expectationCallbacks = array_filter($this->thenExpectations, static fn (object $item) => $item instanceof Closure);
+
         $events = $aggregate->releaseEvents();
 
-        self::assertEquals($this->expectedEvents, $events, 'The events doesn\'t match the expected events.');
+        self::assertEquals($expectedEvents, $events, 'The events doesn\'t match the expected events.');
+
+        foreach ($expectationCallbacks as $callback) {
+            $callback($aggregate);
+        }
 
         return $this;
     }
@@ -139,7 +155,7 @@ abstract class AggregateRootTestCase extends TestCase
         $this->givenEvents = [];
         $this->when = null;
         $this->parameters = [];
-        $this->expectedEvents = [];
+        $this->thenExpectations = [];
         $this->expectedException = null;
         $this->expectedExceptionMessage = null;
     }

--- a/tests/Unit/Fixture/Profile.php
+++ b/tests/Unit/Fixture/Profile.php
@@ -28,6 +28,10 @@ final class Profile extends BasicAggregateRoot
         return $this->email;
     }
 
+    public function emitsNoEvents(): void
+    {
+    }
+
     #[Handle]
     public static function createProfile(CreateProfile $createProfile): self
     {

--- a/tests/Unit/Test/AggregateRootTestCaseTest.php
+++ b/tests/Unit/Test/AggregateRootTestCaseTest.php
@@ -22,6 +22,7 @@ use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\VisitProfile;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 #[CoversClass(AggregateRootTestCase::class)]
 final class AggregateRootTestCaseTest extends TestCase
@@ -482,6 +483,30 @@ final class AggregateRootTestCaseTest extends TestCase
         $test->assert();
         self::assertTrue($called);
         self::assertSame(3, $test::getCount());
+    }
+
+    public function testThenWithIncompatibleCallback(): void
+    {
+        $test = $this->getTester();
+
+        $test
+            ->given(
+                new ProfileCreated(
+                    ProfileId::fromString('1'),
+                    Email::fromString('hq@patchlevel.de'),
+                ),
+            )
+            ->when(
+                static fn (Profile $profile) => $profile->emitsNoEvents(),
+            )
+            ->then(
+                static function (string $incompatible): void {
+                },
+            );
+
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessageMatches('/Invalid then\(\) callback defined in/');
+        $test->assert();
     }
 
     /** @return Generator<array{array<object>, array<Closure>, array<object>}> */

--- a/tests/Unit/Test/AggregateRootTestCaseTest.php
+++ b/tests/Unit/Test/AggregateRootTestCaseTest.php
@@ -485,6 +485,31 @@ final class AggregateRootTestCaseTest extends TestCase
         self::assertSame(3, $test::getCount());
     }
 
+    public function testThenWithFailingAssertionInCallbackRethrowsOriginalError(): void
+    {
+        $test = $this->getTester();
+
+        $test
+            ->given(
+                new ProfileCreated(
+                    ProfileId::fromString('1'),
+                    Email::fromString('hq@patchlevel.de'),
+                ),
+            )
+            ->when(
+                static fn (Profile $profile) => $profile->emitsNoEvents(),
+            )
+            ->then(
+                static function (Profile $profile): void {
+                    self::assertSame('unexpected-id', $profile->id()->toString(), 'Expected fail!');
+                },
+            );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Expected fail!');
+        $test->assert();
+    }
+
     public function testThenWithIncompatibleCallback(): void
     {
         $test = $this->getTester();

--- a/tests/Unit/Test/AggregateRootTestCaseTest.php
+++ b/tests/Unit/Test/AggregateRootTestCaseTest.php
@@ -349,6 +349,141 @@ final class AggregateRootTestCaseTest extends TestCase
         self::assertSame(1, $test::getCount());
     }
 
+    public function testThenWithEventAndCallback(): void
+    {
+        $test = $this->getTester();
+        $called = false;
+
+        $test
+            ->given(
+                new ProfileCreated(
+                    ProfileId::fromString('1'),
+                    Email::fromString('hq@patchlevel.de'),
+                ),
+            )
+            ->when(
+                static fn (Profile $profile) => $profile->visitProfile(new VisitProfile(ProfileId::fromString('2'))),
+            )
+            ->then(
+                new ProfileVisited(ProfileId::fromString('2')),
+                static function (Profile $profile) use (&$called): void {
+                    self::assertSame('1', $profile->id()->toString());
+                    $called = true;
+                },
+            );
+
+        $test->assert();
+        self::assertTrue($called);
+        self::assertSame(3, $test::getCount());
+    }
+
+    public function testThenWithCallbackMixedBetweenEvents(): void
+    {
+        $test = $this->getTester();
+        $called = false;
+
+        $test
+            ->given(
+                new ProfileCreated(
+                    ProfileId::fromString('1'),
+                    Email::fromString('hq@patchlevel.de'),
+                ),
+            )
+            ->when(
+                static fn (Profile $profile) => $profile->visitProfile(new VisitProfile(ProfileId::fromString('2'))),
+            )
+            ->then(
+                static function (Profile $profile) use (&$called): void {
+                    self::assertSame('1', $profile->id()->toString());
+                    $called = true;
+                },
+                new ProfileVisited(ProfileId::fromString('2')),
+            );
+
+        $test->assert();
+        self::assertTrue($called);
+        self::assertSame(3, $test::getCount());
+    }
+
+    public function testThenWithMultipleCallbacks(): void
+    {
+        $test = $this->getTester();
+        $callbackCallCount = 0;
+
+        $test
+            ->given(
+                new ProfileCreated(
+                    ProfileId::fromString('1'),
+                    Email::fromString('hq@patchlevel.de'),
+                ),
+            )
+            ->when(
+                static fn (Profile $profile) => $profile->visitProfile(new VisitProfile(ProfileId::fromString('2'))),
+            )
+            ->then(
+                new ProfileVisited(ProfileId::fromString('2')),
+                static function () use (&$callbackCallCount): void {
+                    $callbackCallCount++;
+                },
+                static function () use (&$callbackCallCount): void {
+                    $callbackCallCount++;
+                },
+            );
+
+        $test->assert();
+        self::assertSame(2, $callbackCallCount);
+        self::assertSame(2, $test::getCount());
+    }
+
+    public function testThenWithCallbackOnCreation(): void
+    {
+        $test = $this->getTester();
+        $called = false;
+
+        $test
+            ->when(
+                static fn () => Profile::createProfile(new CreateProfile(ProfileId::fromString('1'), Email::fromString('hq@patchlevel.de'))),
+            )
+            ->then(
+                new ProfileCreated(ProfileId::fromString('1'), Email::fromString('hq@patchlevel.de')),
+                static function (Profile $profile) use (&$called): void {
+                    self::assertSame('1', $profile->id()->toString());
+                    $called = true;
+                },
+            );
+
+        $test->assert();
+        self::assertTrue($called);
+        self::assertSame(3, $test::getCount());
+    }
+
+    public function testThenWithOnlyCallbacks(): void
+    {
+        $test = $this->getTester();
+        $called = false;
+
+        $test
+            ->given(
+                new ProfileCreated(
+                    ProfileId::fromString('1'),
+                    Email::fromString('hq@patchlevel.de'),
+                ),
+            )
+            ->when(
+                static fn (Profile $profile) => $profile->emitsNoEvents(),
+            )
+            ->then(
+                static function (Profile $profile) use (&$called): void {
+                    self::assertSame('1', $profile->id()->toString());
+                    $called = true;
+                },
+            );
+
+        $test->assert();
+        self::assertTrue($called);
+        self::assertSame(3, $test::getCount());
+    }
+
     /** @return Generator<array{array<object>, array<Closure>, array<object>}> */
     public static function provideVariousTestCases(): iterable
     {

--- a/tests/Unit/Test/AggregateRootTestCaseTest.php
+++ b/tests/Unit/Test/AggregateRootTestCaseTest.php
@@ -19,10 +19,10 @@ use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\ProfileError;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\ProfileId;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\ProfileVisited;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\VisitProfile;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use TypeError;
 
 #[CoversClass(AggregateRootTestCase::class)]
 final class AggregateRootTestCaseTest extends TestCase
@@ -504,8 +504,8 @@ final class AggregateRootTestCaseTest extends TestCase
                 },
             );
 
-        $this->expectException(TypeError::class);
-        $this->expectExceptionMessageMatches('/Invalid then\(\) callback defined in/');
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessageMatches('/then\(\) callback defined in .+ failed:/');
         $test->assert();
     }
 


### PR DESCRIPTION
Closes #20 

Add the ability to pass `Closure` callbacks to `then()` alongside expected events, enabling assertions on the aggregate's internal state after events have been applied.


## Motivation

When testing aggregates, you often need to verify not just the emitted events but also the resulting aggregate state (e.g., public properties or getter values set in `apply` methods). Previously, there was no built-in way to assert on the aggregate instance within the fluent test API.

## Changes

- **`AggregateRootTestCase::then()`** now accepts a mix of event objects and `Closure(object): void` callbacks. Closures receive the aggregate instance and are executed after event assertions. Event order is preserved regardless of callback placement.
- When `then()` receives **only closures** (no event objects), it strictly asserts that zero events were emitted.
- Incompatible callbacks (wrong type hint) are caught and re-thrown as a `TypeError` with the callback's file/line for better DX.
- Add `Profile::emitsNoEvents()` test fixture method.
- Update README with a new "Asserting aggregate state" section and usage example.

## Example

```php
$this
    ->given(new ProfileCreated($id, $email))
    ->when(static fn (Profile $profile) => $profile->visitProfile($visitorId))
    ->then(
        new ProfileVisited($visitorId),
        static fn (Profile $profile) => self::assertSame('1', $profile->id()->toString()),
    );
```
