### PR TITLE
Enable PHPUnit mocks in tests

### DIFF
--- a/src/Test/AggregateRootTestCase.php
+++ b/src/Test/AggregateRootTestCase.php
@@ -28,10 +28,12 @@ abstract class AggregateRootTestCase extends TestCase
 
     /** @var array<mixed> */
     private array $parameters = [];
+    private object|null $aggregate = null;
 
     /** @var array<object|Closure> */
     private array $thenExpectations = [];
 
+    private Throwable|null $thrownException = null;
     /** @var class-string<Throwable>|null */
     private string|null $expectedException = null;
     private string|null $expectedExceptionMessage = null;
@@ -41,6 +43,7 @@ abstract class AggregateRootTestCase extends TestCase
 
     final public function given(object ...$events): self
     {
+        $this->aggregate = null;
         $this->givenEvents = $events;
 
         return $this;
@@ -51,6 +54,42 @@ abstract class AggregateRootTestCase extends TestCase
     {
         $this->when = $callable;
         $this->parameters = $parameters;
+
+        if ($this->givenEvents) {
+            $this->aggregate = $this->aggregateClass()::createFromEvents($this->givenEvents);
+        }
+
+        try {
+            $callableOrCommand = $this->when;
+            $return = null;
+
+            if ($callableOrCommand instanceof Closure) {
+                /** @var AggregateRoot|null $return */
+                $return = $callableOrCommand($this->aggregate);
+            } else {
+                foreach (HandlerFinder::findInClass($this->aggregateClass()) as $handler) {
+                    if (!$callableOrCommand instanceof $handler->commandClass) {
+                        continue;
+                    }
+
+                    $reflection = new ReflectionClass($this->aggregateClass());
+                    $reflectionMethod = $reflection->getMethod($handler->method);
+
+                    /** @var AggregateRoot|null $return */
+                    $return = $reflectionMethod->invokeArgs($handler->static ? null : $this->aggregate, [$callableOrCommand, ...$this->parameters]);
+                }
+            }
+
+            if ($this->aggregate !== null && $return instanceof AggregateRoot) {
+                throw new AggregateAlreadySet();
+            }
+
+            if ($this->aggregate === null) {
+                $this->aggregate = $return;
+            }
+        } catch (Throwable $throwable) {
+            $this->thrownException = $throwable;
+        }
 
         return $this;
     }
@@ -89,60 +128,28 @@ abstract class AggregateRootTestCase extends TestCase
             throw new NoWhenProvided();
         }
 
-        $aggregate = null;
-
-        if ($this->givenEvents) {
-            $aggregate = $this->aggregateClass()::createFromEvents($this->givenEvents);
-        }
-
-        try {
-            $callableOrCommand = $this->when;
-            $return = null;
-
-            if ($callableOrCommand instanceof Closure) {
-                $return = $callableOrCommand($aggregate);
-            } else {
-                foreach (HandlerFinder::findInClass($this->aggregateClass()) as $handler) {
-                    if (!$callableOrCommand instanceof $handler->commandClass) {
-                        continue;
-                    }
-
-                    $reflection = new ReflectionClass($this->aggregateClass());
-                    $reflectionMethod = $reflection->getMethod($handler->method);
-
-                    $return = $reflectionMethod->invokeArgs($handler->static ? null : $aggregate, [$callableOrCommand, ...$this->parameters]);
-                }
-            }
-
-            if ($aggregate !== null && $return instanceof AggregateRoot) {
-                throw new AggregateAlreadySet();
-            }
-
-            if ($aggregate === null) {
-                $aggregate = $return;
-            }
-        } catch (Throwable $throwable) {
-            $this->handleException($throwable);
+        if ($this->thrownException !== null) {
+            $this->handleException($this->thrownException);
 
             return $this;
         }
 
         $this->expectedExceptionWasNotThrown();
 
-        if (!$aggregate instanceof AggregateRoot) {
+        if (!$this->aggregate instanceof AggregateRoot) {
             throw new NoAggregateCreated();
         }
 
         $expectedEvents = array_values(array_filter($this->thenExpectations, static fn (object $item) => !$item instanceof Closure));
         $expectationCallbacks = array_filter($this->thenExpectations, static fn (object $item) => $item instanceof Closure);
 
-        $events = $aggregate->releaseEvents();
+        $events = $this->aggregate->releaseEvents();
 
         self::assertEquals($expectedEvents, $events, 'The events doesn\'t match the expected events.');
 
         foreach ($expectationCallbacks as $callback) {
             try {
-                $callback($aggregate);
+                $callback($this->aggregate);
             } catch (Throwable $t) {
                 $reflection = new ReflectionFunction($callback);
 
@@ -169,6 +176,8 @@ abstract class AggregateRootTestCase extends TestCase
         $this->thenExpectations = [];
         $this->expectedException = null;
         $this->expectedExceptionMessage = null;
+        $this->aggregate = null;
+        $this->thrownException = null;
     }
 
     private function handleException(Throwable $throwable): void

--- a/tests/Unit/Fixture/Notifier.php
+++ b/tests/Unit/Fixture/Notifier.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture;
+
+interface Notifier
+{
+    public function notify(): void;
+}

--- a/tests/Unit/Fixture/Profile.php
+++ b/tests/Unit/Fixture/Profile.php
@@ -33,10 +33,14 @@ final class Profile extends BasicAggregateRoot
     }
 
     #[Handle]
-    public static function createProfile(CreateProfile $createProfile): self
+    public static function createProfile(CreateProfile $createProfile, Notifier|null $notifier = null): self
     {
         $self = new self();
         $self->recordThat(new ProfileCreated($createProfile->id, $createProfile->email));
+
+        if ($notifier) {
+            $notifier->notify();
+        }
 
         return $self;
     }

--- a/tests/Unit/Test/AggregateRootTestCaseTest.php
+++ b/tests/Unit/Test/AggregateRootTestCaseTest.php
@@ -13,6 +13,7 @@ use Patchlevel\EventSourcing\PhpUnit\Test\NoWhenProvided;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\CreateProfile;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\CreateProfileWithFailure;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\Notifier;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\PhpUnit\Tests\Unit\Fixture\ProfileError;
@@ -232,29 +233,6 @@ final class AggregateRootTestCaseTest extends TestCase
         self::assertSame(1, $test::getCount());
     }
 
-    public function testVisitedDoubleAssert(): void
-    {
-        $test = $this->getTester();
-
-        $test
-            ->given(
-                new ProfileCreated(
-                    ProfileId::fromString('1'),
-                    Email::fromString('hq@patchlevel.de'),
-                ),
-            )
-            ->when(
-                static fn (Profile $profile) => $profile->visitProfile(new VisitProfile(ProfileId::fromString('2'))),
-            )
-            ->then(
-                new ProfileVisited(ProfileId::fromString('2')),
-            );
-
-        $test->assert();
-        $test->assert();
-        self::assertSame(2, $test::getCount());
-    }
-
     public function testCreation(): void
     {
         $test = $this->getTester();
@@ -310,7 +288,7 @@ final class AggregateRootTestCaseTest extends TestCase
 
         $test
             ->when(
-                static fn () => 'no aggregate as return',
+                static fn () => null,
             )
             ->then(
                 new ProfileVisited(ProfileId::fromString('2')),
@@ -340,6 +318,21 @@ final class AggregateRootTestCaseTest extends TestCase
             );
 
         $this->expectException(AggregateAlreadySet::class);
+        $test->assert();
+        self::assertSame(1, $test::getCount());
+    }
+
+    public function testCreationWithMock(): void
+    {
+        $test = $this->getTester();
+
+        $notifier = $this->createMock(Notifier::class);
+        $notifier->expects($this->once())->method('notify');
+
+        $test
+            ->when(new CreateProfile(ProfileId::fromString('1'), Email::fromString('hq@patchlevel.de')), $notifier)
+            ->then(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('hq@patchlevel.de')));
+
         $test->assert();
         self::assertSame(1, $test::getCount());
     }


### PR DESCRIPTION
Move execution into `when` instead of the `#[After]` hook. This enables unit testing with phpunit mocks, as they are currently cleanuped before asserting.